### PR TITLE
gitignore: ignore Java VM logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .DS_Store
 /build
 /captures
+
+# Ignore virtual machine crash logs
+# http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
Instead of ignoring all _.log files just ignore for the moment Java VM
logs which are always named as 'hs_err_pid_.log'.

Please see the following for documentation:
http://www.java.com/en/download/help/error_hotspot.xml

Signed-off-by: Djalal Harouni tixxdz@opendz.org
